### PR TITLE
Sending validation arguments in the :required option.

### DIFF
--- a/lib/enumerate_it.rb
+++ b/lib/enumerate_it.rb
@@ -127,14 +127,14 @@
 #  p.divorced? #=> false
 #
 # - If you pass the :create_scopes option as 'true', it will create a scope method for each enumeration option (this option defaults to false):
-# 
+#
 #   class Person < ActiveRecord::Base
 #     has_enumeration_for :relationship_status, :with => RelationshipStatus, :create_scopes => true
 #   end
-# 
+#
 #   Person.married.to_sql # => SELECT "people".* FROM "people" WHERE "people"."relationship_status" = 1
-# 
-# NOTE: The :create_scopes option can only be used for Rails.version >= 3.0.0. 
+#
+# NOTE: The :create_scopes option can only be used for Rails.version >= 3.0.0.
 #
 # - If your class can manage validations and responds to :validates_inclusion_of, it will create this
 # validation:
@@ -309,7 +309,11 @@ module EnumerateIt
 
     def set_validations(attribute, options)
       validates_inclusion_of(attribute, :in => options[:with].list, :allow_blank => true) if self.respond_to?(:validates_inclusion_of)
-      validates_presence_of(attribute) if options[:required] and self.respond_to?(:validates_presence_of)
+
+      if options[:required] && respond_to?(:validates_presence_of)
+        opts = options[:required].is_a?(Hash) ? options[:required] : {}
+        validates_presence_of(attribute, opts)
+      end
     end
   end
 

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -173,7 +173,7 @@ describe EnumerateIt do
         end
       end
 
-      it "when called, the scopes create the correct query" do          
+      it "when called, the scopes create the correct query" do
         TestEnumeration.enumeration do |symbol, pair|
           TestClass.should_receive(:where).with(:foobar => pair.firs)
           TestClass.send symbol
@@ -276,6 +276,13 @@ describe EnumerateIt::Base do
         ActiveRecordStub.should_receive(:validates_presence_of)
         class ActiveRecordStub
           has_enumeration_for :bla, :with => TestEnumeration, :required => true
+        end
+      end
+
+      it "passes the given options to the validation method" do
+        ActiveRecordStub.should_receive(:validates_presence_of).with(:bla, :if => :some_method)
+        class ActiveRecordStub
+          has_enumeration_for :bla, :with => TestEnumeration, :required => { :if => :some_method }
         end
       end
 


### PR DESCRIPTION
Adding support to options like `has_enumeration_for :field, :required => { :if => :some_method? }`.

BTW, using the `validates` method from ActiveModel 3 could lead to a cleaner code - like `validates attribute, :required => options[:required] ...` without using an empty hash.

[]'s.
