### PR TITLE
Remove duplications in my enumerations!

### DIFF
--- a/lib/enumerate_it.rb
+++ b/lib/enumerate_it.rb
@@ -181,7 +181,14 @@ module EnumerateIt
   class Base
     @@registered_enumerations = {}
 
-    def self.associate_values(values_hash)
+    def self.associate_values(*args)
+      if args.first.is_a?(Hash)
+        values_hash = args.first
+      else
+        values_hash = {}
+        args.map{|v| values_hash[v] = v.to_s }
+      end
+
       register_enumeration normalize_enumeration(values_hash)
       values_hash.each_pair { |value_name, attributes| define_enumeration_constant value_name, attributes[0] }
     end

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -26,6 +26,10 @@ class TestEnumerationWithExtendedBehaviour < EnumerateIt::Base
   end
 end
 
+class TestEnumerationWithList < EnumerateIt::Base
+  associate_values :first, :second
+end
+
 class Foobar < EnumerateIt::Base
   associate_values(
     :bar => 'foo'
@@ -242,6 +246,17 @@ describe EnumerateIt::Base do
   describe ".values_for" do
     it "returns an array with the corresponding values for a string array representing some of the enumeration's values" do
       TestEnumeration.values_for(%w(VALUE_1 VALUE_2)).should == [TestEnumeration::VALUE_1, TestEnumeration::VALUE_2]
+    end
+  end
+
+  context 'associate values with a list' do
+    it "creates constants for each enumeration value" do
+      TestEnumerationWithList::FIRST.should == "first"
+      TestEnumerationWithList::SECOND.should == "second"
+    end
+
+    it "returns an array with the values and human representations" do
+      TestEnumerationWithList.to_a.should == [['First', 'first'], ['Second', 'second']]
     end
   end
 


### PR DESCRIPTION
Hi Cássio, I have an project and I have a lot of enumerate_it class with this behavior:

``` ruby
class MyFieldStatus < EnumerateIt::Base
  associate_values :first => 'first', :second => 'second'
end
```

So, with this patch allow to use like this:

``` ruby
class MyFieldStatus < EnumerateIt::Base
  associate_values :first, :second
end
```

Thanks for the project :)
