### PR TITLE
Fixing a bug in which migrations could fail when enumerate_it was used

### DIFF
--- a/lib/enumerate_it.rb
+++ b/lib/enumerate_it.rb
@@ -319,7 +319,7 @@ module EnumerateIt
     def create_scopes(klass, attribute_name)
       klass.enumeration.keys.each do |option|
         if respond_to? :scope
-          scope option, where(attribute_name => klass.enumeration[option].first)
+          scope option, lambda { where(attribute_name => klass.enumeration[option].first)}
         end
       end
     end


### PR DESCRIPTION
Occasionally, when a migration needed to load a class that enumerate_it has was used on, the automatically generated scopes would attempt to access the DB, and could fail (breaking the migration) if the table corresponding to the model did not yet exist.

I've wrapped the scopes in lambdas to prevent this from happening.
