### PR TITLE
Respect superclass enumerations on subclasses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    enumerate_it (0.7.13)
-      activesupport (>= 2.3.2)
+    enumerate_it (0.7.14)
+      activesupport (>= 3.0.0)
 
 GEM
   remote: http://rubygems.org/

--- a/enumerate_it.gemspec
+++ b/enumerate_it.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = EnumerateIt::VERSION
 
-  gem.add_dependency "activesupport", ">= 2.3.2"
+  gem.add_dependency "activesupport", ">= 3.0.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", ">= 2.5.0"

--- a/lib/enumerate_it.rb
+++ b/lib/enumerate_it.rb
@@ -276,6 +276,8 @@ module EnumerateIt
 
   module ClassMethods
     def has_enumeration_for(attribute, options = {})
+      self.enumerations = self.enumerations.dup
+
       define_enumeration_class attribute, options
       set_validations attribute, options
       create_enumeration_humanize_method options[:with], attribute
@@ -288,10 +290,6 @@ module EnumerateIt
       if options[:create_scopes]
         create_scopes options[:with], attribute
       end
-    end
-
-    def enumerations
-      @_enumerations ||= {}
     end
 
     private
@@ -355,6 +353,9 @@ module EnumerateIt
   end
 
   def self.included(receiver)
+    receiver.class_attribute :enumerations, :instance_writer => false, :instance_reader => false
+    receiver.enumerations = {}
+
     receiver.extend ClassMethods
   end
 end

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -73,6 +73,20 @@ describe EnumerateIt do
       TestClass.enumerations[:foobar].should == TestEnumeration
     end
 
+    context 'use the same enumeration from an inherited class' do
+      before do
+        class SomeClass < BaseClass
+        end
+        @target = SomeClass.new
+      end
+
+      it 'should have use the correct class' do
+        @base = BaseClass.new
+        @base.class.enumerations[:foobar].should == TestEnumeration
+        @target.class.enumerations[:foobar].should == TestEnumeration
+      end
+    end
+
     context 'declaring a simple enum on an inherited class' do
       before do
         class SomeClass < BaseClass

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'rspec/autorun'
 
 require 'rubygems'
 require "active_support"
+require "active_support/core_ext/class/attribute"
 require "active_support/core_ext/string/inflections"
 require 'active_support/core_ext/object/to_json'
 


### PR DESCRIPTION
Previously, this was the behavior:

``` ruby
class Unico::Person
  has_enumeration_for :gender
end

class Person < Unico::Person
end

Unico::Person.enumerations
# => {:gender => Gender}

Person.enumerations
# => {}
```

After this commit, subclasses will inherit the superclass enumerations:

``` ruby
class Unico::Person
  has_enumeration_for :gender
end

class Person < Unico::Person
end

Unico::Person.enumerations
# => {:gender => Gender}

Person.enumerations
# => {:gender => Gender}
```
