### PR TITLE
Creating enumerations using predefined constants.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -98,6 +98,14 @@ You can also create enumerations in the following ways:
      associate_values :married => 1, :single => 2
    end
 
+* Defining value constants and calling 'associate_values_with_consts' method. If you use any IDE, this way of creating enumerations is preferable, because in this case IDE can parse defined constants and show them in code autocomplete. Example below does completely the same as previous one:
+
+   class RelationshipStatus < EnumerateIt::Base
+     MARRIED = 1
+     SINGLE  = 2
+
+     associate_values_with_consts
+   end
 
 == Using enumerations
 

--- a/lib/enumerate_it.rb
+++ b/lib/enumerate_it.rb
@@ -214,6 +214,15 @@ module EnumerateIt
       values_hash.each_pair { |value_name, attributes| define_enumeration_constant value_name, attributes[0] }
     end
 
+
+    def self.associate_values_with_consts
+      # Build hash from predefined constants
+      values = {}
+      constants.each{|const| values[const.downcase] = const_get(const)}
+      associate_values(values)
+    end
+
+
     def self.list
       enumeration.values.map { |value| value[0] }.sort
     end

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -30,6 +30,16 @@ class TestEnumerationWithList < EnumerateIt::Base
   associate_values :first, :second
 end
 
+
+class TestEnumerationWithConsts < EnumerateIt::Base
+  FIRST     = 0
+  SECOND    = 1
+  THIRD     = 2
+
+  associate_values_with_consts
+end
+
+
 class Foobar < EnumerateIt::Base
   associate_values(
     :bar => 'foo'
@@ -303,6 +313,20 @@ describe EnumerateIt::Base do
       TestEnumerationWithList.to_a.should == [['First', 'first'], ['Second', 'second']]
     end
   end
+
+
+  context 'associate values with predefined constants' do
+    it "creates constants for each enumeration value" do
+      TestEnumerationWithConsts::FIRST.should == 0
+      TestEnumerationWithConsts::SECOND.should == 1
+      TestEnumerationWithConsts::THIRD.should == 2
+    end
+
+    it "returns an array with the values and human representations" do
+      TestEnumerationWithConsts.to_a.should == [['First', 0], ['Second', 1], ['Third', 2]]
+    end
+  end
+
 
   context "when included in ActiveRecord::Base" do
     before :each do


### PR DESCRIPTION
I have implemented ability to create enumerations in different way:

```
class SomeEnum < EnumerateIt::Base
  FIRST = 1
  SECOND = 2
  associate_values_with_consts
  # The same as:
  # associate_values :first => 1, :second => 2
end
```

This way of enum creation allows IDE to parse constants to show them in code autocomplete and to use in code analysis.
Tests added, readme updated. 

Thanks for EnumerateIt :).
