### PR TITLE
Adding :prefix option for has_enumeration_for

### DIFF
--- a/lib/enumerate_it.rb
+++ b/lib/enumerate_it.rb
@@ -285,8 +285,8 @@ module EnumerateIt
       create_enumeration_humanize_method options[:with], attribute
       store_enumeration options[:with], attribute
       if options[:create_helpers]
-        create_helper_methods options[:with], attribute, options[:prefix]
-        create_mutator_methods options[:with], attribute, options[:prefix]
+        create_helper_methods options[:with], attribute, options[:create_helpers]
+        create_mutator_methods options[:with], attribute, options[:create_helpers]
       end
 
       if options[:create_scopes]
@@ -310,8 +310,8 @@ module EnumerateIt
       end
     end
 
-    def create_helper_methods(klass, attribute_name, prefix)
-      prefix_name = "#{attribute_name}_" if prefix
+    def create_helper_methods(klass, attribute_name, helpers)
+      prefix_name = "#{attribute_name}_" if helpers.is_a?(Hash) && helpers[:prefix]
 
       class_eval do
         klass.enumeration.keys.each do |option|
@@ -330,8 +330,8 @@ module EnumerateIt
       end
     end
 
-    def create_mutator_methods(klass, attribute_name, prefix)
-      prefix_name = "#{attribute_name}_" if prefix
+    def create_mutator_methods(klass, attribute_name, helpers)
+      prefix_name = "#{attribute_name}_" if helpers.is_a?(Hash) && helpers[:prefix]
 
       class_eval do
         klass.enumeration.each_pair do |key, values|

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -174,7 +174,7 @@ describe EnumerateIt do
     context "with :prefix option" do
       before :each do
         class TestClass
-          has_enumeration_for :foobar, :with => TestEnumeration, :create_helpers => true, :prefix => true
+          has_enumeration_for :foobar, :with => TestEnumeration, :create_helpers => { :prefix => true }
         end
       end
 


### PR DESCRIPTION
Hi Cássio!

First let me apologize for my bad English and also because this is my first pull request, hope to do it right. XD

My name is Igor Leroy and I work with Cairo and Sobrinho in Nohup and always use your enumerate_it in our projects. =)

However there was a situation where I needed to create a feature to generate prefixes, helpers, I'll show you an example:

``` ruby
  has_enumeration_for :ordered, :with => MileageControlGroup, :create_helpers => true
  has_enumeration_for :grouped, :with => MileageControlGroup, :create_helpers => true
```

The objects `grouped` and `ordered` use the same Enumeration, but I need helpers unique to each object, for example `ordered_name?` and `grouped_name?` for my views on some reports that we do.

Now just do

``` ruby
has_enumeration_for :grouped, :with => MileageControlGroup, :create_helpers => true, :prefix => true
```

and solved my problem.

I hope you accept my Pull Request and thank you for this gem. ;)
