### PR TITLE
It's better to have supplied sort order. Isn't it?

### DIFF
--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -19,7 +19,7 @@ module EnumerateIt
     end
 
     def self.to_a
-      enumeration.values.map {|value| [translate(value[1]), value[0]] }.sort_by { |value| value[0] }
+      enumeration.values.map {|value| [translate(value[1]), value[0]] }
     end
 
     def self.length


### PR DESCRIPTION
``` ruby
RelationshipStatus.to_a
=> [["Divorced", 4], ["Married", 2], ["Single", 1], ["Widow", 3]]
```

vs

``` ruby
RelationshipStatus.to_a
=> [["Single", 1], ["Married", 2], ["Widow", 3], ["Divorced", 4]]
```
