### PR TITLE
Adding :none sort mode to enumeration

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -133,6 +133,7 @@ The `sort_by` methods accept one of the following values:
 * `:translation`: The default behavior, will sort the returned values based on translations.
 * `:value`: Will sort the returned values based on values.
 * `:name`: Will sort the returned values based on the name of each enumeration option.
+* `:none`: Will return values in order that was passed to associate_values call.
 
 == Using enumerations
 

--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -81,7 +81,8 @@ module EnumerateIt
       {
         :value       => lambda { |k, v| v[0] },
         :name        => lambda { |k, v| k },
-        :translation => lambda { |k, v| translate(v[1]) }
+        :translation => lambda { |k, v| translate(v[1]) },
+        :none        => lambda { |k, v| nil }
       }[sort_mode || :translation]
     end
 

--- a/spec/enumerate_it/base_spec.rb
+++ b/spec/enumerate_it/base_spec.rb
@@ -132,19 +132,25 @@ describe EnumerateIt::Base do
     context "by value" do
       let(:sort_mode) { :value }
 
-      it { should == [["xyz", "1"], ["fgh", "2"], ["abc", "3"]] }
+      it { should == [["jkl", "0"], ["xyz", "1"], ["fgh", "2"], ["abc", "3"]] }
     end
 
     context "by name" do
       let(:sort_mode) { :name }
 
-      it { should == [["fgh", "2"], ["xyz", "1"], ["abc", "3"]] }
+      it { should == [["fgh", "2"], ["xyz", "1"], ["abc", "3"], ["jkl", "0"]] }
     end
 
     context "by translation" do
       let(:sort_mode) { :translation }
 
-      it { should == [["abc", "3"] ,["fgh", "2"], ["xyz", "1"]] }
+      it { should == [["abc", "3"] ,["fgh", "2"], ["jkl", "0"], ["xyz", "1"]] }
+    end
+
+    context "by nothing" do
+      let(:sort_mode) { :none }
+
+      it { should == [["xyz", "1"], ["fgh", "2"], ["abc", "3"], ["jkl", "0"] ] }
     end
   end
 

--- a/spec/support/test_classes.rb
+++ b/spec/support/test_classes.rb
@@ -45,7 +45,8 @@ def create_enumeration_class_with_sort_mode(sort_mode)
     associate_values(
       :foo  => ["1", "xyz"],
       :bar  => ["2", "fgh"],
-      :zomg => ["3", "abc"]
+      :omg => ["3", "abc"],
+      :zomg => ["0", "jkl"]
     )
   end
 end


### PR DESCRIPTION
Hi there.
After you closed this (https://github.com/cassiomarques/enumerate_it/pull/30) i realized that the thing i needed - wasn't really introduced. In my app i actually wanted to return enumeration in order I used when invoking associate_values. So i kind of added another sort_mode :none to the list of usable modes. I guess it might not work in ruby 1.8, but as of 1.9 hashes preserve key order - it will work for me.
One thing to consider - maybe don't do sorting at all if :none is set, but for now i just integrated this option into the working code.
Also i changed tests a bit, so that none of sort results repeat.
