### PR TITLE
Improve create-scopes spec

### DIFF
--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -262,9 +262,15 @@ describe EnumerateIt do
     end
 
     context "when the hosting class do not respond to :scope" do
+      before do
+        class GenericClass
+          extend EnumerateIt
+        end
+      end
+
       it "raises no errors" do
         expect {
-          setup_enumeration
+          GenericClass.send(:has_enumeration_for, :foobar, :with => TestEnumeration, :create_scopes => true)
         }.to_not raise_error
       end
     end


### PR DESCRIPTION
Hi Cassio,

I was studying tests using the EnumerateIt's specs and i found a issue with this one.

The problem is that setup_enumeration method uses a Class that is an ActiveRecord. It always responds to :scope, so the spec never really tests the case.

What do you think?

Thanks
