### PR TITLE
removes unnecessary return on select_with_object block

### DIFF
--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -126,7 +126,6 @@ module EnumerateIt
 
         args.each_with_object({}) do |value, hash|
           hash[value] = value.to_s
-          hash
         end
       end
     end


### PR DESCRIPTION
Hi, @lucascaton!

Thanks for your work on this gem. Just doing a quick saturday morning read since I'm planning to use enumerate_it on my project. I very much enjoyed your code, very well structured! I'd just like to ask if this return value is really necessary for some reason? Normally, we see that return value there because the `Enumerable#inject` requires that the memo be returned. But, AFAIK, `Enumerable#select_with_object` comes exactly to solve that issue?

I ran all the specs after removing that return code and everything is running fine.

I'll leave to your discretion whether or not it's a detail worth addressing now or in the future.

Cheers, and thanks again for enumerate_it!