### PR TITLE
Add 'each_key' method

### DIFF
--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -7,7 +7,7 @@ module EnumerateIt
 
       attr_reader :sort_mode
 
-      def_delegators :enumeration, :keys
+      def_delegators :enumeration, :keys, :each_key
 
       def associate_values(*args)
         values = values_hash(args)

--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -1,7 +1,13 @@
+require 'forwardable'
+
 module EnumerateIt
   class Base
     class << self
+      extend Forwardable
+
       attr_reader :sort_mode
+
+      def_delegators :enumeration, :keys
 
       def associate_values(*args)
         values = values_hash(args)
@@ -72,10 +78,6 @@ module EnumerateIt
         return if key.nil?
 
         (enumeration[key.to_sym] || []).first
-      end
-
-      def keys
-        enumeration.keys
       end
 
       def key_for(value)

--- a/spec/enumerate_it/base_spec.rb
+++ b/spec/enumerate_it/base_spec.rb
@@ -85,6 +85,16 @@ describe EnumerateIt::Base do
     end
   end
 
+  describe '.each_key' do
+    it "yields each enumeration's key" do
+      keys = []
+      TestEnumeration.each_key do |key|
+        keys << key
+      end
+      expect(keys).to eq(%i[value_1 value_2 value_3])
+    end
+  end
+
   describe '.each_value' do
     it "yields each enumeration's value" do
       values = []


### PR DESCRIPTION
A recent cop introduced by Rubocop (called [`Style/HashEachMethods`](https://rubocop.readthedocs.io/en/latest/cops_style/#stylehasheachmethods)) suggests to replace:

```diff
- Enum.keys.each { ...
  # with:
+ Enum.each_key { ...
```

In order to make it work though, `Enum` would have to respond to the `each_key` method.
Well, now it does :)

Also, enumerations already respond to `each_value`, so it makes sense to responds to `each_key` as well.