### PR TITLE
Fix .value_for to not search for constants in ancestors

### DIFF
--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -69,7 +69,7 @@ module EnumerateIt
       end
 
       def value_for(value)
-        const_get(value.to_sym)
+        const_get(value.to_sym, false)
       rescue NameError
         nil
       end

--- a/spec/enumerate_it/base_spec.rb
+++ b/spec/enumerate_it/base_spec.rb
@@ -178,6 +178,12 @@ describe EnumerateIt::Base do
         expect(TestEnumeration.value_for('THIS_IS_WRONG')).to be_nil
       end
     end
+
+    context 'when a constant named after the received value exists as an ancestor' do
+      it 'returns nil' do
+        expect(TestEnumeration.value_for('Module')).to be_nil
+      end
+    end
   end
 
   describe '.value_from_key' do


### PR DESCRIPTION
Right now `.value_for` might return any constant that exists in the enum ancestors.

This causes some weird behaviors like:
`MyEnum.value_for('Module')` to return the Module class.

This PR fixes this behavior by passing `false` to the optional inherit argument of `.const_get`.

Docs here: https://ruby-doc.org/core-2.5.1/Module.html#method-i-const_get