### PR TITLE
Fix generator when running it on Rails 7 (fixes #102)

### DIFF
--- a/lib/generators/enumerate_it/enum/USAGE
+++ b/lib/generators/enumerate_it/enum/USAGE
@@ -1,5 +1,5 @@
 Description:
-    Creates an EnumerateIt class an its locale file
+    Creates an EnumerateIt class and its locale file
 
 Example:
     rails g enumerate_it:enum CivilStatus single married divorced widower concubinage separated stable
@@ -11,5 +11,5 @@ Example:
     rails g enumerate_it:enum CivilStatus single:1 married:2 divorced:3 widower:4
 
     This will create:
-        app/enumerations/civil_status.rb with `associate_values :single => 1, :married => 2, :divorced => 2, :widower => 4`
+        app/enumerations/civil_status.rb with `associate_values single: 1, married: 2, divorced: 3, widower: 4`
         config/locales/civil_status.yml

--- a/lib/generators/enumerate_it/enum/enum_generator.rb
+++ b/lib/generators/enumerate_it/enum/enum_generator.rb
@@ -3,7 +3,7 @@ module EnumerateIt
     class EnumGenerator < Rails::Generators::NamedBase
       source_root File.expand_path('templates', __dir__)
 
-      argument :attributes, type: 'array'
+      argument :attributes, type: :hash
 
       class_option :singular, type: 'string', desc: 'Singular name for i18n'
 

--- a/lib/generators/enumerate_it/enum/templates/locale.yml
+++ b/lib/generators/enumerate_it/enum/templates/locale.yml
@@ -1,6 +1,6 @@
 <%= default_lang %>:
   enumerations:
     <%= singular_name %>:
-    <%- locale_fields.each do |name| -%>
+    <%- locale_fields.each do |name, _| -%>
       <%= name %>: '<%= name.humanize %>'
     <%- end -%>


### PR DESCRIPTION
EnumerateIt generator was broken when running it on a Rails 7 app, as reported on issue #102.

This PR fixes it by replacing Thor's `array` argument type with `hash`.

Out of curiosity, these were the docs and code I reviewed as part of the investigation to fix the issue:

- https://guides.rubyonrails.org/generators.html
- https://github.com/rails/thor/blob/3e2dfe9/lib/thor/parser/argument.rb#L5
- https://github.com/lucascaton/enumerate_it/pull/29/files
- https://blog.saeloun.com/2021/06/29/rails-7-generators-will-raise-errors-when-invalid.html
- https://github.com/rails/rails/pull/42311