### PR TITLE
Fix generator when using array instead of hash

### DIFF
--- a/lib/generators/enumerate_it/enum/enum_generator.rb
+++ b/lib/generators/enumerate_it/enum/enum_generator.rb
@@ -29,10 +29,6 @@ module EnumerateIt
         singular_name
       end
 
-      def locale_fields
-        attributes.map(&:name)
-      end
-
       def fields
         if attributes.empty? 
           args

--- a/lib/generators/enumerate_it/enum/enum_generator.rb
+++ b/lib/generators/enumerate_it/enum/enum_generator.rb
@@ -30,7 +30,7 @@ module EnumerateIt
       end
 
       def fields
-        if attributes.empty? 
+        if attributes.empty?
           args
         elsif attributes.first.type == :string
           attributes.map(&:name)

--- a/lib/generators/enumerate_it/enum/enum_generator.rb
+++ b/lib/generators/enumerate_it/enum/enum_generator.rb
@@ -34,7 +34,9 @@ module EnumerateIt
       end
 
       def fields
-        if attributes.first.type == :string
+        if attributes.empty? 
+          args
+        elsif attributes.first.type == :string
           attributes.map(&:name)
         else
           attributes.map { |attribute| [attribute.name, attribute.type] }

--- a/lib/generators/enumerate_it/enum/templates/locale.yml
+++ b/lib/generators/enumerate_it/enum/templates/locale.yml
@@ -1,6 +1,6 @@
 <%= default_lang %>:
   enumerations:
     <%= singular_name %>:
-    <%- locale_fields.each do |name, _| -%>
+    <%- fields.each do |name, _| -%>
       <%= name %>: '<%= name.humanize %>'
     <%- end -%>


### PR DESCRIPTION
The `argument :attributes, type: :hash` doesn't accept arrays, this generates an empty `attributes`. To solve this problem, the `args` (the array provided to generator) is returned when `attributes` is empty.

Closes #104,