### PR TITLE
Generate _key methods for attributes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.1)
+    activemodel (7.1.3.2)
+      activesupport (= 7.1.3.2)
+    activerecord (7.1.3.2)
+      activemodel (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      timeout (>= 0.4.0)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -35,6 +41,7 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
+    mini_portile2 (2.8.6)
     minitest (5.20.0)
     mutex_m (0.1.2)
     parallel (1.23.0)
@@ -88,7 +95,10 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     thor (1.2.2)
+    timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -98,6 +108,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord
   appraisal
   bundler
   enumerate_it!
@@ -107,6 +118,7 @@ DEPENDENCIES
   rubocop
   rubocop-rake
   rubocop-rspec
+  sqlite3
   wwtd
 
 BUNDLED WITH

--- a/enumerate_it.gemspec
+++ b/enumerate_it.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', '>= 5.0.7.2'
 
+  gem.add_development_dependency 'activerecord'
   gem.add_development_dependency 'appraisal'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'pry'
@@ -30,5 +31,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rubocop-rake'
   gem.add_development_dependency 'rubocop-rspec'
+  gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'wwtd'
 end

--- a/lib/enumerate_it/class_methods.rb
+++ b/lib/enumerate_it/class_methods.rb
@@ -5,6 +5,7 @@ module EnumerateIt
 
       define_enumeration_class(attribute, options)
       create_enumeration_humanize_method(options[:with], attribute)
+      create_enumeration_key_method(options[:with], attribute)
       store_enumeration(options[:with], attribute)
 
       handle_options(attribute, options)
@@ -34,6 +35,16 @@ module EnumerateIt
           values = klass.enumeration.values.detect { |v| v[0] == send(attribute_name) }
 
           values ? klass.translate(values[1]) : nil
+        end
+      end
+    end
+
+    def create_enumeration_key_method(klass, attribute_name)
+      class_eval do
+        define_method "#{attribute_name}_key" do
+          value = public_send(attribute_name)
+
+          value ? klass.key_for(value) : nil
         end
       end
     end

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -28,6 +28,15 @@ describe EnumerateIt do
       expect(target.foobar_humanize).to be_nil
     end
 
+    it 'creates the key method' do
+      expect(target.foobar_key).to eq(:value_2)
+    end
+
+    it 'if the attribute is blank, the key method returns nil' do
+      target.foobar = nil
+      expect(target.foobar_key).to be_nil
+    end
+
     it 'defaults to not creating helper methods' do
       expect(target).not_to respond_to(:value_1?)
     end


### PR DESCRIPTION
Hey there! First of all, thank you so much for maintaining this gem, love it!

Im my company we're heavy users of `enumerate_it` and we're having a ton of enum classes. Let's cosider the following example:

```ruby
class ExampleEnum < EnumerateIt::Base
  associate_values foo: 0, bar: 1
end
```

```ruby
class ActiveRecordModel < ApplicationRecord
  has_enumeration_for :foo, with: ExampleEnum
end
```

We're using numbers as values to save the planet and some space in our db

Later, somewhere in the code to get the human readable value back we need to use `key_for` on the enum class like that

```ruby
ActiveRecordModel.all.map do |record|
  {
    example: 123,
    foo: ExampleEnum.key_for(record.foo)
  }
end
```

So although our model's attribute is already tied to a specific enum class, we need to type the constant name again, calling `key_for` on it. Not only it requires to always remember the class name of enum which is associated with the attribute, but also can lead to mistakes, when accidentally using `key_for` on wrong enum (e.g both of them have integers as values in associated hash that are starting from 0)

So my proposal would be to generate `#{attribute_name}_key` methods similar to `#{attribute_name}_humanize` to simplify things:

```ruby
ActiveRecordModel.all.map do |record|
  {
    example: 123,
    foo: record.foo_key
  }
end
```

This way the enum user code will look cleaner and will be free of accidental mistakes related to the usage of wrong enum classes

The implementation seems pretty straightforward, but for sure i may be missing something. Please, let me know what do you think, thanks a lot in advance!

P.S I added `activerecord` and `sqlite` to development dependencies as specs are not running for me locally without doing so. `spec_helper` requires `active_record`, so I assume this is the right thing to do :)