### PR TITLE
Skip `sqlite3` v2 for now

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,19 +4,21 @@ require 'json'
 rails_versions = JSON.parse(Net::HTTP.get(URI('https://rubygems.org/api/v1/versions/rails.json')))
   .group_by { |version| version['number'] }.keys.grep_v(/rc|racecar|beta|pre/)
 
-%w[5.0 5.1 5.2 6.0 6.1 7.0 7.1].each do |version|
-  appraise "rails_#{version}" do
+%w[5.0 5.1 5.2 6.0 6.1 7.0 7.1].each do |rails_version|
+  appraise "rails_#{rails_version}" do
     current_version = rails_versions
-      .select { |key| key.match(/\A#{version}/) }
+      .select { |key| key.match(/\A#{rails_version}/) }
       .max { |a, b| Gem::Version.new(a) <=> Gem::Version.new(b) }
 
     gem 'activesupport', "~> #{current_version}"
     gem 'activerecord',  "~> #{current_version}"
 
-    if Gem::Version.new(version) > Gem::Version.new(5.0)
-      gem 'sqlite3'
-    else
+    if Gem::Version.new(rails_version) <= Gem::Version.new(5.0)
       gem 'sqlite3', '< 1.4'
+    elsif Gem::Version.new(RUBY_VERSION) < '3'
+      gem 'sqlite3', '< 2'
+    else
+      gem 'sqlite3'
     end
   end
 end

--- a/Appraisals
+++ b/Appraisals
@@ -15,10 +15,15 @@ rails_versions = JSON.parse(Net::HTTP.get(URI('https://rubygems.org/api/v1/versi
 
     if Gem::Version.new(rails_version) <= Gem::Version.new(5.0)
       gem 'sqlite3', '< 1.4'
-    elsif Gem::Version.new(RUBY_VERSION) < '3'
-      gem 'sqlite3', '< 2'
     else
-      gem 'sqlite3'
+      # v2.x isn't yet working. See: https://github.com/sparklemotion/sqlite3-ruby/issues/529
+      gem 'sqlite3', '< 2'
     end
+
+    # elsif Gem::Version.new(RUBY_VERSION) < '3'
+    #   gem 'sqlite3', '< 2'
+    # else
+    #   gem 'sqlite3'
+    # end
   end
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sqlite3 (2.0.1)
+    sqlite3 (1.7.3)
       mini_portile2 (~> 2.8.0)
     thor (1.2.2)
     tzinfo (2.0.6)
@@ -110,7 +110,7 @@ DEPENDENCIES
   rubocop
   rubocop-rake
   rubocop-rspec
-  sqlite3
+  sqlite3 (< 2)
   wwtd
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ GEM
     json (2.6.3)
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
+    mini_portile2 (2.8.6)
     minitest (5.20.0)
     mutex_m (0.1.2)
     parallel (1.23.0)
@@ -88,6 +89,8 @@ GEM
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    sqlite3 (2.0.1)
+      mini_portile2 (~> 2.8.0)
     thor (1.2.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -107,6 +110,7 @@ DEPENDENCIES
   rubocop
   rubocop-rake
   rubocop-rspec
+  sqlite3
   wwtd
 
 BUNDLED WITH

--- a/enumerate_it.gemspec
+++ b/enumerate_it.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rubocop-rake'
   gem.add_development_dependency 'rubocop-rspec'
+  gem.add_development_dependency 'sqlite3'
   gem.add_development_dependency 'wwtd'
 end

--- a/enumerate_it.gemspec
+++ b/enumerate_it.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rubocop'
   gem.add_development_dependency 'rubocop-rake'
   gem.add_development_dependency 'rubocop-rspec'
-  gem.add_development_dependency 'sqlite3'
+  gem.add_development_dependency 'sqlite3', '< 2'
   gem.add_development_dependency 'wwtd'
 end

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.1.7'
 gem 'activesupport', '~> 5.1.7'
-gem 'sqlite3'
+gem 'sqlite3', '< 2'
 
 gemspec path: '../'

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 
 gem 'activerecord', '~> 5.2.8.1'
 gem 'activesupport', '~> 5.2.8.1'
-gem 'sqlite3'
+gem 'sqlite3', '< 2'
 
 gemspec path: '../'

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -4,6 +4,6 @@ source 'https://rubygems.org'
 
 gem 'activerecord', '~> 6.0.6.1'
 gem 'activesupport', '~> 6.0.6.1'
-gem 'sqlite3'
+gem 'sqlite3', '< 2'
 
 gemspec path: '../'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 6.1.7.6'
-gem 'activesupport', '~> 6.1.7.6'
-gem 'sqlite3'
+gem 'activerecord', '~> 6.1.7.7'
+gem 'activesupport', '~> 6.1.7.7'
+gem 'sqlite3', '< 2'
 
 gemspec path: '../'

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 7.0.8'
-gem 'activesupport', '~> 7.0.8'
-gem 'sqlite3'
+gem 'activerecord', '~> 7.0.8.1'
+gem 'activesupport', '~> 7.0.8.1'
+gem 'sqlite3', '< 2'
 
 gemspec path: '../'

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -2,8 +2,8 @@
 
 source 'https://rubygems.org'
 
-gem 'activerecord', '~> 7.1.1'
-gem 'activesupport', '~> 7.1.1'
-gem 'sqlite3'
+gem 'activerecord', '~> 7.1.3.2'
+gem 'activesupport', '~> 7.1.3.2'
+gem 'sqlite3', '< 2'
 
 gemspec path: '../'


### PR DESCRIPTION
v2 changelog: https://github.com/sparklemotion/sqlite3-ruby/blob/main/CHANGELOG.md#200--2024-04-17

Skipping v2 for now due to this issue: https://github.com/sparklemotion/sqlite3-ruby/issues/529