### PR TITLE
Add `custom_helpers` block to propagate enum class methods as model instance helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ At a glance:
 ```ruby
 class RelationshipStatus < EnumerateIt::Base
   associate_values :single, :married, :divorced
+
+  custom_helpers do
+    def ever_married?(value)
+      [MARRIED, DIVORCED].include?(value)
+    end
+  end
 end
 
 class Person < ApplicationRecord
@@ -31,6 +37,7 @@ end
 person = Person.new(relationship_status: RelationshipStatus::MARRIED)
 
 person.married? #=> true
+person.ever_married? #=> true
 person.relationship_status_humanize #=> 'Married'
 Person.married.to_sql #=> SELECT "people".* FROM "people" WHERE "people"."relationship_status" = "married"
 RelationshipStatus.to_a #=> [['Divorced', 'divorced'], ['Married', 'married'], ['Single', 'single']]
@@ -362,6 +369,57 @@ This will create:
   > On ActiveRecord objects, mutator methods like `married!` call `save!`
   > immediately, running callbacks and raising on validation failure. They are
   > not pure setters.
+
+  You can also define custom helper methods on the enumeration class using
+  a `custom_helpers` block. These become class methods on the enumeration, and when
+  `create_helpers: true` is used, instance methods on the model that delegate
+  the attribute's current value automatically:
+
+  ```ruby
+  class RelationshipStatus < EnumerateIt::Base
+    associate_values :single, :married, :divorced
+
+    custom_helpers do
+      def ever_married?(value)
+        [MARRIED, DIVORCED].include?(value)
+      end
+    end
+  end
+  ```
+
+  Available as a class method on the enumeration:
+
+  ```ruby
+  RelationshipStatus.ever_married?(RelationshipStatus::MARRIED)  #=> true
+  RelationshipStatus.ever_married?(RelationshipStatus::DIVORCED) #=> true
+  RelationshipStatus.ever_married?(RelationshipStatus::SINGLE)   #=> false
+  ```
+
+  Available as instance methods when `create_helpers: true`:
+
+  ```ruby
+  class Person < ApplicationRecord
+    has_enumeration_for :relationship_status, with: RelationshipStatus, create_helpers: true
+  end
+
+  p = Person.new(relationship_status: RelationshipStatus::DIVORCED)
+  p.ever_married? #=> true
+  ```
+
+  The `prefix` option works the same as for built-in helpers:
+
+  ```ruby
+  class Person < ApplicationRecord
+    has_enumeration_for :relationship_status,
+      with: RelationshipStatus, create_helpers: { prefix: true }
+  end
+
+  p.relationship_status_ever_married? #=> true
+  ```
+
+  Custom helper methods return `nil` when the attribute is `nil`. If a method
+  name collides with an already-defined class method on the enumeration, an
+  `ArgumentError` is raised at load time.
 
 - A scope method for each enumeration option if you pass the `create_scopes`
   option as `true`:

--- a/README.md
+++ b/README.md
@@ -371,9 +371,7 @@ This will create:
   > not pure setters.
 
   You can also define custom helper methods on the enumeration class using
-  a `custom_helpers` block. These become class methods on the enumeration, and when
-  `create_helpers: true` is used, instance methods on the model that delegate
-  the attribute's current value automatically:
+  a `custom_helpers` block:
 
   ```ruby
   class RelationshipStatus < EnumerateIt::Base
@@ -387,7 +385,7 @@ This will create:
   end
   ```
 
-  Available as a class method on the enumeration:
+  These become class methods on the enumeration:
 
   ```ruby
   RelationshipStatus.ever_married?(RelationshipStatus::MARRIED)  #=> true
@@ -395,18 +393,19 @@ This will create:
   RelationshipStatus.ever_married?(RelationshipStatus::SINGLE)   #=> false
   ```
 
-  Available as instance methods when `create_helpers: true`:
+  When `create_helpers: true` is used, they also become instance methods on the
+  model:
 
   ```ruby
   class Person < ApplicationRecord
     has_enumeration_for :relationship_status, with: RelationshipStatus, create_helpers: true
   end
 
-  p = Person.new(relationship_status: RelationshipStatus::DIVORCED)
-  p.ever_married? #=> true
+  person = Person.new(relationship_status: RelationshipStatus::DIVORCED)
+  person.ever_married? #=> true
   ```
 
-  The `prefix` option works the same as for built-in helpers:
+  The `prefix` option also applies to custom helpers:
 
   ```ruby
   class Person < ApplicationRecord
@@ -414,7 +413,8 @@ This will create:
       with: RelationshipStatus, create_helpers: { prefix: true }
   end
 
-  p.relationship_status_ever_married? #=> true
+  person = Person.new(relationship_status: RelationshipStatus::DIVORCED)
+  person.relationship_status_ever_married? #=> true
   ```
 
   Custom helper methods return `nil` when the attribute is `nil`. If a method

--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -100,9 +100,11 @@ module EnumerateIt
 
         mod = Module.new(&block)
         methods = mod.instance_methods(false)
-
         collisions = methods & singleton_class.instance_methods
-        raise ArgumentError, "#{collisions.join(', ')} already defined." if collisions.any?
+
+        if collisions.any?
+          raise ArgumentError, "Custom helper(s) '#{collisions.join(', ')}' would override existing EnumerateIt::Base methods"
+        end
 
         @custom_helper_methods.concat(methods)
         extend mod

--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -102,9 +102,9 @@ module EnumerateIt
         methods = mod.instance_methods(false)
         collisions = methods & singleton_class.instance_methods
 
-        if collisions.any?
-          raise ArgumentError, "Custom helper(s) '#{collisions.join(', ')}' would override existing EnumerateIt::Base methods"
-        end
+        raise ArgumentError, <<~MESSAGE.chomp if collisions.any?
+          Custom helper(s) '#{collisions.join(', ')}' would override existing EnumerateIt::Base methods
+        MESSAGE
 
         @custom_helper_methods.concat(methods)
         extend mod

--- a/lib/enumerate_it/base.rb
+++ b/lib/enumerate_it/base.rb
@@ -95,6 +95,23 @@ module EnumerateIt
         I18n.t("enumerations.#{name.underscore}.#{value.to_s.underscore}", default: default)
       end
 
+      def custom_helpers(&block)
+        @custom_helper_methods ||= []
+
+        mod = Module.new(&block)
+        methods = mod.instance_methods(false)
+
+        collisions = methods & singleton_class.instance_methods
+        raise ArgumentError, "#{collisions.join(', ')} already defined." if collisions.any?
+
+        @custom_helper_methods.concat(methods)
+        extend mod
+      end
+
+      def custom_helper_methods
+        @custom_helper_methods || []
+      end
+
       private
 
       def sorted_map

--- a/lib/enumerate_it/class_methods.rb
+++ b/lib/enumerate_it/class_methods.rb
@@ -17,7 +17,7 @@ module EnumerateIt
       set_validations(attribute, options) unless options[:skip_validation]
 
       if options[:create_helpers]
-        %w[create_helper_methods create_mutator_methods create_polymorphic_methods].each do |method|
+        %w[create_helper_methods create_mutator_methods create_polymorphic_methods create_custom_helper_methods].each do |method|
           send(method, options[:with], attribute, options[:create_helpers])
         end
       end
@@ -96,6 +96,21 @@ module EnumerateIt
           value = public_send(attribute_name)
 
           klass.const_get(klass.key_for(value).to_s.camelize).new if value
+        end
+      end
+    end
+
+    def create_custom_helper_methods(klass, attribute_name, helpers)
+      return unless klass.custom_helper_methods.any?
+
+      prefix_name = "#{attribute_name}_" if helpers.is_a?(Hash) && helpers[:prefix]
+
+      class_eval do
+        klass.custom_helper_methods.each do |method_name|
+          define_method "#{prefix_name}#{method_name}" do
+            value = send(attribute_name)
+            klass.public_send(method_name, value) unless value.nil?
+          end
         end
       end
     end

--- a/lib/enumerate_it/class_methods.rb
+++ b/lib/enumerate_it/class_methods.rb
@@ -1,5 +1,5 @@
 module EnumerateIt
-  module ClassMethods
+  module ClassMethods # rubocop:disable Metrics/ModuleLength
     def has_enumeration_for(attribute, options = {})
       self.enumerations = enumerations.dup
 
@@ -17,7 +17,8 @@ module EnumerateIt
       set_validations(attribute, options) unless options[:skip_validation]
 
       if options[:create_helpers]
-        %w[create_helper_methods create_mutator_methods create_polymorphic_methods create_custom_helper_methods].each do |method|
+        %w[create_helper_methods create_mutator_methods create_polymorphic_methods
+           create_custom_helper_methods].each do |method|
           send(method, options[:with], attribute, options[:create_helpers])
         end
       end

--- a/spec/enumerate_it/base_spec.rb
+++ b/spec/enumerate_it/base_spec.rb
@@ -250,7 +250,7 @@ describe EnumerateIt::Base do
               end
             end
           end
-        end.to raise_error(ArgumentError, /list/)
+        end.to raise_error(ArgumentError, "Custom helper(s) 'list' would override existing EnumerateIt::Base methods")
       end
     end
   end

--- a/spec/enumerate_it/base_spec.rb
+++ b/spec/enumerate_it/base_spec.rb
@@ -228,6 +228,48 @@ describe EnumerateIt::Base do
     end
   end
 
+  describe '.custom_helpers' do
+    context 'when methods are defined inside the block' do
+      it 'become class methods on the enum' do
+        expect(TestEnumerationWithCustomHelpers.lookup('1')).to eq(:one)
+        expect(TestEnumerationWithCustomHelpers.lookup('2')).to eq(:two)
+        expect(TestEnumerationWithCustomHelpers.boolean?('1')).to be(true)
+        expect(TestEnumerationWithCustomHelpers.boolean?('2')).to be(false)
+      end
+    end
+
+    context 'when a custom helper name collides with a built-in method' do
+      it 'raises an ArgumentError' do
+        expect do
+          Class.new(EnumerateIt::Base) do
+            associate_values :collision
+
+            custom_helpers do
+              def list
+                '...'
+              end
+            end
+          end
+        end.to raise_error(ArgumentError, /list/)
+      end
+    end
+  end
+
+  describe '.custom_helper_methods' do
+    context 'when methods are defined inside custom_helpers block' do
+      it 'returns the registered names' do
+        expect(TestEnumerationWithCustomHelpers.custom_helper_methods)
+          .to eq(%i[lookup boolean?])
+      end
+    end
+
+    context 'when there is no .custom_helpers block on an enum' do
+      it 'returns an empty array' do
+        expect(TestEnumeration.custom_helper_methods).to eq([])
+      end
+    end
+  end
+
   context 'associate values with a list' do
     it 'creates constants for each enumeration value' do
       expect(TestEnumerationWithList::FIRST).to  eq('first')

--- a/spec/enumerate_it/base_spec.rb
+++ b/spec/enumerate_it/base_spec.rb
@@ -239,8 +239,8 @@ describe EnumerateIt::Base do
     end
 
     context 'when a custom helper name collides with a built-in method' do
-      it 'raises an ArgumentError' do
-        expect do
+      let(:build_colliding_enum) do
+        proc do
           Class.new(EnumerateIt::Base) do
             associate_values :collision
 
@@ -250,7 +250,14 @@ describe EnumerateIt::Base do
               end
             end
           end
-        end.to raise_error(ArgumentError, "Custom helper(s) 'list' would override existing EnumerateIt::Base methods")
+        end
+      end
+
+      it 'raises an ArgumentError' do
+        expect(&build_colliding_enum).to raise_error(
+          ArgumentError,
+          "Custom helper(s) 'list' would override existing EnumerateIt::Base methods"
+        )
       end
     end
   end

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -42,6 +42,15 @@ describe EnumerateIt do
       expect(target).not_to respond_to(:value_1?)
     end
 
+    it 'defaults to not creating custom helper methods' do
+      klass = Class.new do
+        extend EnumerateIt
+        attr_accessor :foobar
+        has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers
+      end
+      expect(klass.new).not_to respond_to(:lookup)
+    end
+
     it 'stores the enumeration class in a class-level hash' do
       expect(test_class.enumerations[:foobar]).to eq(TestEnumeration)
     end
@@ -287,6 +296,59 @@ describe EnumerateIt do
           expect(target.foo_strategy.print('Gol')).to eq('Whoa!: Gol')
         end
       end
+    end
+
+    context 'with custom_helpers defined on the enumeration' do
+      context 'creates methods that delegates to the enum' do
+        let :test_class_with_custom_helpers do
+          Class.new do
+            extend EnumerateIt
+
+            attr_accessor :foobar
+
+            has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers, create_helpers: true
+
+            def initialize(foobar)
+              @foobar = foobar
+            end
+          end
+        end
+
+        it 'returns value respective to attribute value' do
+          target = test_class_with_custom_helpers.new(TestEnumerationWithCustomHelpers::VALUE_ONE)
+          expect(target.lookup).to eq(:one)
+          expect(target.boolean?).to be(true)
+        end
+
+        it 'returns nil when attribute is nil' do
+          target = test_class_with_custom_helpers.new(nil)
+          expect(target.lookup).to be_nil
+          expect(target.boolean?).to be_nil
+        end
+      end
+
+      context 'create methods with prefix that delegates to the enum' do
+        let :test_class_with_prefixed_custom_helpers do
+          Class.new do
+            extend EnumerateIt
+
+            attr_accessor :foobar
+
+            has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers, create_helpers: { prefix: true }
+
+            def initialize(foobar)
+              @foobar = foobar
+            end
+          end
+        end
+
+        it 'method is prefixed with the attribute name' do
+          target = test_class_with_prefixed_custom_helpers.new(TestEnumerationWithCustomHelpers::VALUE_ONE)
+          expect(target).to respond_to(:foobar_lookup)
+          expect(target).not_to respond_to(:lookup)
+        end
+      end
+
     end
   end
 

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -348,7 +348,6 @@ describe EnumerateIt do
           expect(target).not_to respond_to(:lookup)
         end
       end
-
     end
   end
 

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -344,8 +344,10 @@ describe EnumerateIt do
 
         it 'method is prefixed with the attribute name' do
           target = test_class_with_prefixed_custom_helpers.new(TestEnumerationWithCustomHelpers::VALUE_ONE)
-          expect(target).to respond_to(:foobar_lookup)
+          expect(target.foobar_lookup).to eq(:one)
+          expect(target.foobar_boolean?).to be(true)
           expect(target).not_to respond_to(:lookup)
+          expect(target).not_to respond_to(:boolean?)
         end
       end
     end

--- a/spec/enumerate_it_spec.rb
+++ b/spec/enumerate_it_spec.rb
@@ -45,7 +45,7 @@ describe EnumerateIt do
     it 'defaults to not creating custom helper methods' do
       klass = Class.new do
         extend EnumerateIt
-        attr_accessor :foobar
+
         has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers
       end
       expect(klass.new).not_to respond_to(:lookup)
@@ -306,7 +306,8 @@ describe EnumerateIt do
 
             attr_accessor :foobar
 
-            has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers, create_helpers: true
+            has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers,
+              create_helpers: true
 
             def initialize(foobar)
               @foobar = foobar
@@ -334,7 +335,8 @@ describe EnumerateIt do
 
             attr_accessor :foobar
 
-            has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers, create_helpers: { prefix: true }
+            has_enumeration_for :foobar, with: TestEnumerationWithCustomHelpers,
+              create_helpers: { prefix: true }
 
             def initialize(foobar)
               @foobar = foobar

--- a/spec/support/test_classes.rb
+++ b/spec/support/test_classes.rb
@@ -78,3 +78,17 @@ def create_enumeration_class_with_sort_mode(sort_mode)
     )
   end
 end
+
+class TestEnumerationWithCustomHelpers < EnumerateIt::Base
+  associate_values value_one: '1', value_two: '2'
+
+  custom_helpers do
+    def lookup(value)
+      { '1' => :one, '2' => :two }[value]
+    end
+
+    def boolean?(value)
+      value == '1'
+    end
+  end
+end


### PR DESCRIPTION
Closes #122.

## What this adds
A `custom_helpers` block on `EnumerateIt::Base` that defines methods as class methods on the enum and registers their names so `has_enumeration_for` can generate model instance wrappers automatically.

The generated wrapper returns `nil` when the attribute is `nil` and otherwise delegates to the enum class method passing the attribute value as the single argument.